### PR TITLE
use custom command prefix

### DIFF
--- a/condor/config.py
+++ b/condor/config.py
@@ -31,6 +31,7 @@ class CondorServerConfig(BaseModel):
 
 class Config(BaseModel):
     discord: DiscordConfig
+    command_prefix: str = "condor-"
 
     condor_server: CondorServerConfig
     flight_plans_path: str

--- a/condor/release.py
+++ b/condor/release.py
@@ -1,1 +1,1 @@
-version = "0.1.0"
+version = "0.2.1"

--- a/condor/server_manager.py
+++ b/condor/server_manager.py
@@ -100,11 +100,7 @@ def parse_server_status_list_box_items(status: ServerStatus, list_box_items) -> 
 
 
 def parse_players_list_box_items(status: ServerStatus, list_box_items) -> None:
-    players = []
-    for item in list_box_items:
-        players.append(item)
-
-    status.players = players
+    status.players = list(list_box_items)
 
 
 def get_server_status() -> tuple[ServerStatus, ServerProcess | None]:

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -5,6 +5,8 @@ discord:
 flight_plans_path: C:\Condor3\BotFlightPlans
 condor_path: C:\Condor3
 
+# command_prefix: condor-
+
 condor_server:
   server_name: "VEAF TEST"
   # port: 56278

--- a/main.py
+++ b/main.py
@@ -27,24 +27,24 @@ bot = commands.Bot(command_prefix="/", intents=intents)
 
 logger = logging.getLogger("main")
 
+prefix = get_config().command_prefix
 
-@bot.tree.command(description="Display the help")
+
+@bot.tree.command(name=f"{prefix}help", description="Display the help")
 async def condor(interaction: Interaction):
+    # cmd_prefix
     msg = f"""
 **Condor 3 bot help** - *v{release.version}*
 
 ```        
-Commands: /condor <command>
-        
-    start   start Condor 3 server
-    stop    stop Condor 3 server
-    list    list flight plans
-    show    show informations about a flightplan
-    ping    test if the discord bot is alive
+Commands:
 
-    help    show this help message
+"""
+    for command in bot.tree.get_commands():
+        msg += f"{command.name:10s} {command.description}\n"
+
+    msg += """
 ```
-
 Upload: just send a new Flight Plan (ex: MyFlightPlan.fpl) to this channel.
 
 """
@@ -58,12 +58,12 @@ async def on_ready():
     print(f"✅ bot is logged in as {bot.user}")
 
 
-@bot.tree.command(description="Simple Ping Pong Test command")
+@bot.tree.command(name=f"{prefix}ping", description="Simple Ping Pong Test command")
 async def ping(interaction: Interaction):
     await send_response(interaction, "Pong! 🏓")
 
 
-@bot.tree.command(description="Start condor 3 server")
+@bot.tree.command(name=f"{prefix}start", description="Start condor 3 server")
 async def start(interaction: Interaction):
     status, _ = get_server_status()
     if status.online_status != OnlineStatus.OFFLINE.value:
@@ -94,12 +94,12 @@ async def start(interaction: Interaction):
         await handle_error(interaction, f"an error occured, server not started: {exc}")
 
 
-@bot.tree.command(name="status", description="Refresh condor 3 server status")
+@bot.tree.command(name=f"{prefix}status", description="Refresh condor 3 server status")
 async def status(interaction: Interaction):
     await on_status(interaction)
 
 
-@bot.tree.command(description="Stop condor 3 server")
+@bot.tree.command(name=f"{prefix}stop", description="Stop condor 3 server")
 async def stop(interaction: Interaction):
     try:
         status, _ = get_server_status()
@@ -125,12 +125,12 @@ async def stop(interaction: Interaction):
         await handle_error(interaction, f"an error occured, server not stopped: {exc}")
 
 
-@bot.tree.command(name="list", description="List flight plans available")
+@bot.tree.command(name=f"{prefix}list", description="List flight plans available")
 async def _list(interaction: Interaction):
     await on_list_flight_plans(interaction)
 
 
-@bot.tree.command(description="Show informations about a flightplan")
+@bot.tree.command(name=f"{prefix}show", description="Show informations about a flightplan")
 async def show(interaction: Interaction):
     try:
         view = SelectViewFlightPlan(interaction.user)
@@ -173,6 +173,11 @@ def main():
         return
 
     print(f"[yellow]admin channel[/yellow]: [blue]{config.discord.admin_channel_id}[/blue]")
+    print(f"[yellow]command prefix[/yellow]: [blue]{config.command_prefix}[/blue]")
+    print("[yellow]registered commands[/yellow]:")
+    for command in bot.tree.get_commands():
+        print(f"  - [blue]{command.name}[/blue]  {command.description}")
+
     bot.run(config.discord.api_token)
 
 


### PR DESCRIPTION
## Summary by Sourcery

Introduces a custom command prefix for the bot commands, configurable via the config file. Updates the bot to use the configured prefix for all commands.

Enhancements:
- Allows configuration of a custom command prefix.
- Updates the help command to dynamically list available commands with their descriptions.
- Prints the registered commands and the command prefix on startup.