### PR TITLE
display server version in /condor-status command

### DIFF
--- a/CHANGELOG_38.md
+++ b/CHANGELOG_38.md
@@ -1,0 +1,1 @@
+- ADDED display server version in /condor-status command

--- a/condor/server_manager.py
+++ b/condor/server_manager.py
@@ -8,6 +8,7 @@ from pywinauto import Application
 from pywinauto.application import WindowSpecification, ProcessNotFoundError
 
 CONDOR_DEDICATED_EXE = "CondorDedicated.exe"
+CONDOR_DEDICATED_WINDOW_TITLE_PREFIX = "Condor dedicated server version"
 
 
 class OnlineStatus(IntEnum):
@@ -19,6 +20,7 @@ class OnlineStatus(IntEnum):
 
 
 class ServerStatus(BaseModel):
+    version: str = "unknown"
     online_status: OnlineStatus = OnlineStatus.OFFLINE
     time: str | None = None
     stop_join_in: str | None = None
@@ -110,6 +112,10 @@ def get_server_status() -> tuple[ServerStatus, ServerProcess | None]:
         return ServerStatus(online_status=OnlineStatus.OFFLINE), None
 
     status = ServerStatus(online_status=OnlineStatus.NOT_RUNNING)
+
+    window_title: str = process.window.window_text()
+    if window_title.startswith(CONDOR_DEDICATED_WINDOW_TITLE_PREFIX):
+        status.version = window_title[len(CONDOR_DEDICATED_WINDOW_TITLE_PREFIX) + 1 :].strip()
 
     # a better way than searching all listbox, and matching the top position ?
     list_boxes = process.window.descendants(class_name="TspListBox")

--- a/main.py
+++ b/main.py
@@ -94,7 +94,7 @@ async def start(interaction: Interaction):
         await handle_error(interaction, f"an error occured, server not started: {exc}")
 
 
-@bot.tree.command(name=f"{prefix}status", description="Refresh condor 3 server status")
+@bot.tree.command(name=f"{prefix}status", description="Display condor 3 server status")
 async def status(interaction: Interaction):
     await on_status(interaction)
 

--- a/services/agent.py
+++ b/services/agent.py
@@ -56,7 +56,7 @@ async def on_status(interaction: Interaction) -> None:
     try:
         status, _ = get_server_status()
 
-        msg = SERVER_STATUS_ICONS.get(status.online_status, "⁉️") + " " + str(status.online_status.name) + "\n"
+        msg = f"{SERVER_STATUS_ICONS.get(status.online_status, '⁉️')} {status.online_status.name} - version {status.version}\n"
         if status.time:
             msg += f"**In game time**: {status.time}\n"
         if status.stop_join_in:


### PR DESCRIPTION
Closes #38

## Summary by Sourcery

Add server version display to the Condor server status command

New Features:
- Display the Condor dedicated server version in the /status command output

Enhancements:
- Update server status command description to be more descriptive

Chores:
- Create a changelog entry for the new feature